### PR TITLE
Include middle names in the legal name returned

### DIFF
--- a/lib/abn/client.rb
+++ b/lib/abn/client.rb
@@ -116,7 +116,8 @@ module Abn
       entity.status             = result[:entity_status][:entity_status_code] rescue nil
       entity.main_name          = result[:main_name][:organisation_name] rescue nil
       entity.trading_name       = result[:main_trading_name][:organisation_name] rescue nil
-      entity.legal_name         = "#{result[:legal_name][:given_name]} #{result[:legal_name][:family_name]}" rescue nil
+      combined_names = [result[:legal_name][:given_name], result[:legal_name][:other_given_name], result[:legal_name][:family_name]].select{|x| !x.blank?}.join(' ') rescue nil
+      entity.legal_name         = combined_names rescue nil
       entity.legal_name2        = result[:full_name] rescue nil
       entity.other_trading_name = result[:other_trading_name][:organisation_name] rescue nil
       entity.active_from_date   = result[:entity_status][:effective_from] rescue nil

--- a/lib/abn/version.rb
+++ b/lib/abn/version.rb
@@ -2,6 +2,6 @@
 
 module Abn
 
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 
 end


### PR DESCRIPTION
The results from ABR service includes an 'other_given_name' field which often includes a persons middle names. This should be returned with the 'legal_name' since the result should be able to readily match additional checks against this legal entity. A more accurate name prevents mismatches.

I've bumped the version to 0.0.10 for this.

The change should be backwards compatible for entries where no other given name is provided by the service.