### PR TITLE
Upgrade ruby version to 2.7.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
 
     docker:
-      - image: cimg/ruby:2.5.9
+      - image: cimg/ruby:2.7.7
 
     steps:
       - checkout

--- a/abn_search.gemspec
+++ b/abn_search.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.add_dependency("savon", "~> 2.6")
   s.add_dependency("httparty", "~> 0")
   s.add_dependency("nokogiri", "~> 1.6")
-  s.add_development_dependency "coveralls_reborn", "~> 0.22.0"
-  s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "coveralls_reborn", "~> 0.26.0"
+  s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.5", ">= 3.0"
   s.add_development_dependency "rspec_junit_formatter", "~> 0.2"
   s.add_development_dependency "simplecov", "~> 0"

--- a/spec/abn/client_spec.rb
+++ b/spec/abn/client_spec.rb
@@ -214,8 +214,6 @@ describe Abn::Client do
               abr_payload_search_results: {
                 response: {
                   search_results_list: {
-                    search_results_record: [
-                    ]
                   }
                 }
               }

--- a/spec/abn/client_spec.rb
+++ b/spec/abn/client_spec.rb
@@ -205,6 +205,27 @@ describe Abn::Client do
             change(instance, :errors).to(["Error"])
         end
       end
+      
+      # well at least that's what I'm assuming drives this else clause :grimacing:
+      context "when the business can't be found" do
+        let(:dummy_result) do
+          {
+            abr_search_by_name_response: {
+              abr_payload_search_results: {
+                response: {
+                  search_results_list: {
+                    search_results_record: [
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        end
+
+        it { is_expected.to be_empty }
+ 
+      end
     end
 
     describe "#valid?" do


### PR DESCRIPTION
Because there's no explicit version tag on the gem this will use latest nokogiri.  So this is limited to bumping the ruby version in CI and updating a couple of other dependancies.